### PR TITLE
fix deprecated for v0.6

### DIFF
--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -280,7 +280,7 @@ function find_element(x::XMLElement, n::AbstractString)
 end
 
 function get_elements_by_tagname(x::XMLElement, n::AbstractString)
-    lst = Array(XMLElement, 0)
+    lst = Array{XMLElement,1}()
     for c in child_elements(x)
         if name(c) == n
             push!(lst, c)


### PR DESCRIPTION
Array{T}(::Type{T},m::Int) is deprecated in  Julia v0.6, use Array{T,1}(m) instead.