### PR TITLE
Update errors.jl DOMException  dep inner constructor 

### DIFF
--- a/src/errors.jl
+++ b/src/errors.jl
@@ -18,23 +18,3 @@ end
 immutable XMLTreeError{T<:AbstractString} <: XMLError
     msg::T
 end
-
-const dom_exception_causes = [
-    "Index size error",        #  1
-    "DOM string size error",   #  2
-    "Hierarchy request error", #  3
-    "Wrong document",          #  4
-    "Invalid character",       #  5
-    "No data allowed",         #  6
-    "No modification allowed", #  7
-    "Not found",               #  8
-    "Not supported",           #  9
-    "Inused attribute"         # 10
-]
-
-
-immutable DOMException{T<:AbstractString} <: XMLError
-    code::Int
-    cause::T
-end
-DOMException(code::Integer) = DOMException(code, dom_exception_causes[code])

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -36,6 +36,5 @@ const dom_exception_causes = [
 immutable DOMException{T<:AbstractString} <: XMLError
     code::Int
     cause::T
-
-    DOMException(code::Int) = new(code, dom_exception_causes[code])
 end
+DOMException(code::Integer) = DOMException(code, dom_exception_causes[code])


### PR DESCRIPTION
I removed the inner constructor and made it so that 
`DOMException(1)`, e.g.,   work now without having to specify the type `DOMException{"String"}(1)`


Alternatively can also just force `cause` to be a `String`  (doesn't really matter here)
e.g.
```julia
immutable DOMException <: XMLError
     code::Int
     cause::String
     DOMException(code::Int) = new(code, dom_exception_causes[code])		
end
```
