### PR TITLE
Drop support for 0.6, update CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
+  - 1.0
   - nightly
 notifications:
     email: false
@@ -17,6 +17,6 @@ matrix:
 
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("LightXML")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia --project -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("LightXML")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia --project -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.7
 BinaryProvider 0.3.0
-Compat 0.59

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 0.7
 BinaryProvider 0.3.0
 Compat 0.59

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
-matrix:
-  allow_failures:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: latest
 
 branches:
   only:
@@ -24,19 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"LightXML\"); Pkg.build(\"LightXML\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"LightXML\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -1,4 +1,4 @@
-__precompile__()
+VERSION < v"0.7.0-beta2.199" && __precompile__()
 
 module LightXML
 

--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -1,8 +1,6 @@
 
 module LightXML
 
-using Compat
-
 let depsfile = joinpath(@__DIR__, "..", "deps", "deps.jl")
     if !isfile(depsfile)
         error("LightXML is not properly installed. Run `Pkg.build(\"LightXML\")` and " *

--- a/src/LightXML.jl
+++ b/src/LightXML.jl
@@ -1,4 +1,3 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
 
 module LightXML
 

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -106,7 +106,7 @@ else
     Base.done(it::XMLAttrIter, p::Xptr) = (p == C_NULL)
     Base.next(it::XMLAttrIter, p::Xptr) = (a = XMLAttr(p); (a, a._struct.next))
 end
-Compat.IteratorSize(::Type{XMLAttrIter}) = Base.SizeUnknown()
+IteratorSize(::Type{XMLAttrIter}) = Base.SizeUnknown()
 
 #######################################
 #
@@ -180,7 +180,7 @@ else
     Base.next(it::XMLNodeIter, p::Xptr) = (nd = XMLNode(p); (nd, nd._struct.next))
 end
 
-Compat.IteratorSize(::Type{XMLNodeIter}) = Base.SizeUnknown()
+IteratorSize(::Type{XMLNodeIter}) = Base.SizeUnknown()
 
 child_nodes(nd::XMLNode) = XMLNodeIter(nd._struct.children)
 
@@ -290,7 +290,7 @@ else
         (XMLElement(p), ccall((:xmlNextElementSibling,libxml2), Xptr, (Xptr,), p))
 end
 
-Compat.IteratorSize(::Type{XMLElementIter}) = Base.SizeUnknown()
+IteratorSize(::Type{XMLElementIter}) = Base.SizeUnknown()
 
 child_elements(x::XMLElement) = XMLElementIter(x.node.ptr)
 

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -95,17 +95,12 @@ struct XMLAttrIter
     p::Xptr
 end
 
-@static if isdefined(Base, :iterate)
-    function Base.iterate(it::XMLAttrIter, p::Xptr=it.p)
-        p == C_NULL && return nothing
-        a = XMLAttr(p)
-        (a, a._struct.next)
-    end
-else
-    Base.start(it::XMLAttrIter) = it.p
-    Base.done(it::XMLAttrIter, p::Xptr) = (p == C_NULL)
-    Base.next(it::XMLAttrIter, p::Xptr) = (a = XMLAttr(p); (a, a._struct.next))
+function Base.iterate(it::XMLAttrIter, p::Xptr=it.p)
+    p == C_NULL && return nothing
+    a = XMLAttr(p)
+    (a, a._struct.next)
 end
+
 IteratorSize(::Type{XMLAttrIter}) = Base.SizeUnknown()
 
 #######################################
@@ -168,16 +163,10 @@ struct XMLNodeIter
     p::Xptr
 end
 
-@static if isdefined(Base, :iterate)
-    function Base.iterate(it::XMLNodeIter, p::Xptr=it.p)
-        p == C_NULL && return nothing
-        nd = XMLNode(p)
-        (nd, nd._struct.next)
-    end
-else
-    Base.start(it::XMLNodeIter) = it.p
-    Base.done(it::XMLNodeIter, p::Xptr) = (p == C_NULL)
-    Base.next(it::XMLNodeIter, p::Xptr) = (nd = XMLNode(p); (nd, nd._struct.next))
+function Base.iterate(it::XMLNodeIter, p::Xptr=it.p)
+    p == C_NULL && return nothing
+    nd = XMLNode(p)
+    (nd, nd._struct.next)
 end
 
 IteratorSize(::Type{XMLNodeIter}) = Base.SizeUnknown()
@@ -276,18 +265,9 @@ struct XMLElementIter
     parent_ptr::Xptr
 end
 
-@static if isdefined(Base, :iterate)
-    function Base.iterate(it::XMLElementIter,
-            p::Xptr=ccall((:xmlFirstElementChild,libxml2), Xptr, (Xptr,), it.parent_ptr))
-        p == C_NULL && return nothing
-        XMLElement(p), ccall((:xmlNextElementSibling,libxml2), Xptr, (Xptr,), p)
-    end
-else
-    Base.start(it::XMLElementIter) =
-        ccall((:xmlFirstElementChild,libxml2), Xptr, (Xptr,), it.parent_ptr)
-    Base.done(it::XMLElementIter, p::Xptr) = (p == C_NULL)
-    Base.next(it::XMLElementIter, p::Xptr) =
-        (XMLElement(p), ccall((:xmlNextElementSibling,libxml2), Xptr, (Xptr,), p))
+function Base.iterate(it::XMLElementIter, p::Xptr=ccall((:xmlFirstElementChild, libxml2), Xptr, (Xptr,), it.parent_ptr))
+    p == C_NULL && return nothing
+    XMLElement(p), ccall((:xmlNextElementSibling, libxml2), Xptr, (Xptr,), p)
 end
 
 IteratorSize(::Type{XMLElementIter}) = Base.SizeUnknown()

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -95,9 +95,17 @@ struct XMLAttrIter
     p::Xptr
 end
 
-Base.start(it::XMLAttrIter) = it.p
-Base.done(it::XMLAttrIter, p::Xptr) = (p == C_NULL)
-Base.next(it::XMLAttrIter, p::Xptr) = (a = XMLAttr(p); (a, a._struct.next))
+if isdefined(Base, :iterate)
+    function Base.iterate(it::XMLAttrIter, p::Xptr=it.p)
+        p == C_NULL && return nothing
+        a = XMLAttr(p)
+        (a, a._struct.next)
+    end
+else
+    Base.start(it::XMLAttrIter) = it.p
+    Base.done(it::XMLAttrIter, p::Xptr) = (p == C_NULL)
+    Base.next(it::XMLAttrIter, p::Xptr) = (a = XMLAttr(p); (a, a._struct.next))
+end
 Compat.IteratorSize(::Type{XMLAttrIter}) = Base.SizeUnknown()
 
 #######################################

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -101,7 +101,7 @@ function Base.iterate(it::XMLAttrIter, p::Xptr=it.p)
     (a, a._struct.next)
 end
 
-IteratorSize(::Type{XMLAttrIter}) = Base.SizeUnknown()
+Base.IteratorSize(::Type{XMLAttrIter}) = Base.SizeUnknown()
 
 #######################################
 #
@@ -169,7 +169,7 @@ function Base.iterate(it::XMLNodeIter, p::Xptr=it.p)
     (nd, nd._struct.next)
 end
 
-IteratorSize(::Type{XMLNodeIter}) = Base.SizeUnknown()
+Base.IteratorSize(::Type{XMLNodeIter}) = Base.SizeUnknown()
 
 child_nodes(nd::XMLNode) = XMLNodeIter(nd._struct.children)
 
@@ -270,7 +270,7 @@ function Base.iterate(it::XMLElementIter, p::Xptr=ccall((:xmlFirstElementChild, 
     XMLElement(p), ccall((:xmlNextElementSibling, libxml2), Xptr, (Xptr,), p)
 end
 
-IteratorSize(::Type{XMLElementIter}) = Base.SizeUnknown()
+Base.IteratorSize(::Type{XMLElementIter}) = Base.SizeUnknown()
 
 child_elements(x::XMLElement) = XMLElementIter(x.node.ptr)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using LightXML
-using Compat
 using Test
 
 tests = ["parse", "create", "cdata", "pi"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using LightXML
 using Compat
-using Compat.Test
+using Test
 
 tests = ["parse", "create", "cdata", "pi"]
 


### PR DESCRIPTION
This is on top of #86. Perhaps just merge this and disregard #86 if there's no objection to dropping 0.6.

I intend to make more changes to this branch, just wanted to see if FemtoCleaner could do some of the work for me.