### PR TITLE
Add find_element and get_elements_by_tagname methods

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -120,3 +120,13 @@ function Base.string(xdoc::XMLDocument; encoding::AbstractString="utf-8")
 end
 
 Base.show(io::IO, xdoc::XMLDocument) = print(io, string(xdoc))
+
+function find_element(xdoc::XMLDocument, n::AbstractString)
+    x = root(xdoc)
+    find_element(x, n)
+end
+
+function get_elements_by_tagname(xdoc::XMLDocument, n::AbstractString)
+    x = root(xdoc)
+    get_elements_by_tagname(x, n)
+end

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -283,6 +283,10 @@ function find_element(x::XMLElement, n::AbstractString)
     return nothing
 end
 
+function find_element(x, ns::Vector{<:AbstractString})
+    foldl(find_element, ns; init = x)
+end
+
 function get_elements_by_tagname(x::XMLElement, n::AbstractString)
     lst = Vector{XMLElement}()
     for c in child_elements(x)


### PR DESCRIPTION
1. It is proposed that `find_element` and `get_elements_by_tagname` accept, besides an `XMLElement`, also an `XMLDocument` as first argument.
2. A method `find_element(x, ns::Vector{<:AbstractString})` is implemented. It just folds `find_element` over the vector of abstract strings.