### PR TITLE
Remove +1 in parse_string

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -97,7 +97,7 @@ parse_file(filename::AbstractString, encoding, options::Integer) =
         filename, encoding, options))
 
 parse_string(s::AbstractString) =
-    _check_result(ccall((:xmlParseMemory,libxml2), Xptr, (Xstr, Cint), s, sizeof(s) + 1))
+    _check_result(ccall((:xmlParseMemory,libxml2), Xptr, (Xstr, Cint), s, sizeof(s)))
 
 
 #### output


### PR DESCRIPTION
Fix #122 

Not sure why the `+1` was there to begin with. It seems to create some out of bounds read which libxml2 2.12.0 now catches. 