### PR TITLE
Allow passing encoding and options to parse_string

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -99,6 +99,9 @@ parse_file(filename::AbstractString, encoding, options::Integer) =
 parse_string(s::AbstractString) =
     _check_result(ccall((:xmlParseMemory,libxml2), Xptr, (Xstr, Cint), s, sizeof(s)))
 
+parse_string(s::AbstractString, encoding, options::Integer) =
+    _check_result(ccall((:xmlReadMemory,libxml2), Xptr, (Cstring, Int, Cstring, Cstring, Int),
+        s, sizeof(s), "", encoding, options))
 
 #### output
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -19,8 +19,10 @@ docstr = """
 """
 
 for xdoc = (parse_string(docstr),
+            parse_string(docstr, C_NULL, 64), # 64 == XML_PARSE_NOWARNING
+            parse_string(docstr, "UTF-8", 64),
             parse_file(joinpath(@__DIR__, "ex1.xml")),
-            parse_file(joinpath(@__DIR__, "ex1.xml"), C_NULL, 64), # 64 == XML_PARSE_NOWARNING
+            parse_file(joinpath(@__DIR__, "ex1.xml"), C_NULL, 64),
             parse_file(joinpath(@__DIR__, "ex1.xml"), "UTF-8", 64))
 
 @test version(xdoc) == "1.0"


### PR DESCRIPTION
Give `parse_string` similar functionality as `parse_file`. Addresses issue https://github.com/JuliaIO/LightXML.jl/issues/127 (gives the option to pass XML_PARSE_HUGE if necessary).