### PR TITLE
Bump XML2_jll version up

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 XML2_jll = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
 
 [compat]
-XML2_jll = "~2.9, ~2.10, ~2.11, ~2.12, ~2.13"
+XML2_jll = "~2.9, ~2.10, ~2.11, ~2.12, ~2.13, ~2.14"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Hi, change that enables compatibility downstream: [LSL.jl](https://github.com/abcsds/LSL.jl).